### PR TITLE
styles: fix typo in stylus attribute.

### DIFF
--- a/src/styles/components/Products.styl
+++ b/src/styles/components/Products.styl
@@ -7,7 +7,7 @@
   &-item
     text-decoration none
     box-shadow 8px 14px 38px rgba(39,44,49,.06), 1px 3px 8px rgba(39,44,49,.03)
-    border-radiu 5px
+    border-radius 5px
     margin 0 0 20px 0
     position relative
     &-info


### PR DESCRIPTION
This commit fix a typo in a border-radius attribute.